### PR TITLE
check if stairsplus is available and not only moreblocks

### DIFF
--- a/src/stairsplus.lua
+++ b/src/stairsplus.lua
@@ -51,8 +51,9 @@ There is one in each of the "stairsplus.register_all" sections.
 -- next section of stairsplus stuff. ~LazyJ
 
 if (minetest.get_modpath("moreblocks"))
+and rawget(_G, "stairsplus")
 
--- 'If' MoreBlocks was found, well, 'then' go ahead with this next part:
+-- 'If' MoreBlocks was found and stairsplus is available, well, 'then' go ahead with this next part:
 
 then
 


### PR DESCRIPTION
l removed stairsplus from moreblocks and wasn't able to use your mod.
Maybe searching for the moreblocks mod isn't necessary.