### PR TITLE
Fix Warnings

### DIFF
--- a/src/mapgen.lua
+++ b/src/mapgen.lua
@@ -137,7 +137,7 @@ function snow.make_pine(pos,snow,xmas)
 	if xmas then
 		try_node({x=pos.x,y=pos.y+7,z=pos.z},{name="snow:star_lit"}) -- Added lit star. ~ LazyJ
 	elseif snow
-	and minetest.get_perlin(112,3, 0.5, perlin_scale):get2d({x=pos.x,y=pos.z}) > nosmooth_rarity then
+	and minetest.get_perlin(112,3, 0.5, perlin_scale):get_2d({x=pos.x,y=pos.z}) > nosmooth_rarity then
 		try_node({x=pos.x,y=pos.y+7,z=pos.z},{name="default:snow"})
 	end
 end
@@ -161,7 +161,7 @@ function snow.voxelmanip_pine(pos,a,data)
 				data[a:index(x,pos.y+i,z)] = c_pine_needles
 				if x ~= 0
 				and z ~= 0
-				and perlin1:get2d({x=x,y=z}) > nosmooth_rarity then
+				and perlin1:get_2d({x=x,y=z}) > nosmooth_rarity then
 					local abovenode = a:index(x,pos.y+i+1,z)
 					data[abovenode] = c_snow
 				end
@@ -176,16 +176,16 @@ function snow.voxelmanip_pine(pos,a,data)
 		data[a:index(x-1,y,z)] = c_pine_needles
 		data[a:index(x,y,z+1)] = c_pine_needles
 		data[a:index(x,y,z-1)] = c_pine_needles
-		if perlin1:get2d({x=x+1,y=z}) > nosmooth_rarity then
+		if perlin1:get_2d({x=x+1,y=z}) > nosmooth_rarity then
 			data[a:index(x+1,y+1,z)] = c_snow
 		end
-		if perlin1:get2d({x=x+1,y=z}) > nosmooth_rarity then
+		if perlin1:get_2d({x=x+1,y=z}) > nosmooth_rarity then
 			data[a:index(x-1,y+1,z)] = c_snow
 		end
-		if perlin1:get2d({x=x,y=z+1}) > nosmooth_rarity then
+		if perlin1:get_2d({x=x,y=z+1}) > nosmooth_rarity then
 			data[a:index(x,y+1,z+1)] = c_snow
 		end
-		if perlin1:get2d({x=x,y=z-1}) > nosmooth_rarity then
+		if perlin1:get_2d({x=x,y=z-1}) > nosmooth_rarity then
 			data[a:index(x,y+1,z-1)] = c_snow
 		end
 	end
@@ -194,7 +194,7 @@ function snow.voxelmanip_pine(pos,a,data)
 	end
 	data[a:index(pos.x,pos.y+5,pos.z)] = c_pine_needles
 	data[a:index(pos.x,pos.y+6,pos.z)] = c_pine_needles
-	if perlin1:get2d({x=pos.x,y=pos.z}) > nosmooth_rarity then
+	if perlin1:get_2d({x=pos.x,y=pos.z}) > nosmooth_rarity then
 		data[a:index(pos.x,pos.y+7,pos.z)] = c_snow
 	end
 end

--- a/src/mapgen_v6.lua
+++ b/src/mapgen_v6.lua
@@ -212,7 +212,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 	local pines_tab,pnum = {},1
 
 	get_perlins(x1 - x0 + 1)
-	local nvals_default = perlin_objs.default:get2dMap_flat({x=x0+150, y=z0+50}, nbuf_default)
+	local nvals_default = perlin_objs.default:get_2dMap_flat({x=x0+150, y=z0+50}, nbuf_default)
 	local nvals_cold, nvals_ice, ndia
 
 	-- Choose biomes
@@ -239,7 +239,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 		local in_biome = false
 		local test
 		if nvals_default[ni] < 0.35 then
-			nvals_cold = nvals_cold or perlin_objs.cold:get2dMap_flat({x=x0, y=z0}, nbuf_cold)
+			nvals_cold = nvals_cold or perlin_objs.cold:get_2dMap_flat({x=x0, y=z0}, nbuf_cold)
 			test = math.min(nvals_cold[ni], 1)
 			if is_smooth then
 				if test >= smooth_rarity_max
@@ -291,7 +291,7 @@ minetest.register_on_generated(function(minp, maxp, seed)
 			end
 		else
 			if not nvals_ice then
-				nvals_ice = perlin_objs.ice:get2dMap_flat({x=x0, y=z0}, nbuf_ice)
+				nvals_ice = perlin_objs.ice:get_2dMap_flat({x=x0, y=z0}, nbuf_ice)
 
 				nodes_added = true
 				write_to_map = true

--- a/src/sled.lua
+++ b/src/sled.lua
@@ -81,7 +81,7 @@ local sled = {
 
 local players_sled = {}
 local function join_sled(self, player)
-	local pos = self.object:getpos()
+	local pos = self.object:get_pos()
 	player:setpos(pos)
 	local name = player:get_player_name()
 	players_sled[name] = true
@@ -89,7 +89,7 @@ local function join_sled(self, player)
 	default.player_set_animation(player, "sit" , 30)
 	self.driver = name
 	self.object:set_attach(player, "", {x=0,y=-9,z=0}, {x=0,y=90,z=0})
-	self.object:setyaw(player:get_look_yaw())-- - math.pi/2)
+	self.object:set_yaw(player:get_look_yaw())-- - math.pi/2)
 end
 
 local function leave_sled(self, player)
@@ -156,7 +156,7 @@ end
 
 function sled:on_activate(staticdata)
 	self.object:set_armor_groups({immortal=1})
-	self.object:setacceleration({x=0, y=-10, z=0})
+	self.object:set_acceleration({x=0, y=-10, z=0})
 	if staticdata then
 		self.v = tonumber(staticdata)
 	end
@@ -200,7 +200,7 @@ function sled:on_step(dtime)
 		return
 	end
 	if player:get_player_control().sneak
-	or not accelerating_possible(vector.round(self.object:getpos())) then
+	or not accelerating_possible(vector.round(self.object:get_pos())) then
 		leave_sled(self, player)
 	end
 end
@@ -220,7 +220,7 @@ minetest.register_craftitem("snow:sled", {
 		if players_sled[placer:get_player_name()] then
 			return
 		end
-		local pos = placer:getpos()
+		local pos = placer:get_pos()
 		if accelerating_possible(vector.round(pos)) then
 			pos.y = pos.y+0.5
 

--- a/src/snowball.lua
+++ b/src/snowball.lua
@@ -40,10 +40,10 @@ function snow.shoot_snowball(item, player)
 	local dif = 2*math.sqrt(dir.z*dir.z+dir.x*dir.x)
 	addp.x = dir.z/dif -- + (math.random()-0.5)/5
 	addp.z = -dir.x/dif -- + (math.random()-0.5)/5
-	local pos = vector.add(player:getpos(), addp)
+	local pos = vector.add(player:get_pos(), addp)
 	local obj = minetest.add_entity(pos, "snow:snowball_entity")
-	obj:setvelocity(vector.multiply(dir, snowball_velocity))
-	obj:setacceleration({x=dir.x*-3, y=-get_gravity(), z=dir.z*-3})
+	obj:set_velocity(vector.multiply(dir, snowball_velocity))
+	obj:set_acceleration({x=dir.x*-3, y=-get_gravity(), z=dir.z*-3})
 	obj:get_luaentity().thrower = player:get_player_name()
 	if creative_mode then
 		if not someone_throwing then
@@ -103,13 +103,13 @@ local snow_snowball_ENTITY = {
 
 function snow_snowball_ENTITY.on_activate(self)
 	self.object:set_properties({textures = {"default_snowball.png^[transform"..math.random(0,7)}})
-	self.object:setacceleration({x=0, y=-get_gravity(), z=0})
-	self.lastpos = self.object:getpos()
+	self.object:set_acceleration({x=0, y=-get_gravity(), z=0})
+	self.lastpos = self.object:get_pos()
 	minetest.after(0.1, function(obj)
 		if not obj then
 			return
 		end
-		local vel = obj:getvelocity()
+		local vel = obj:get_velocity()
 		if vel
 		and vel.y ~= 0 then
 			return
@@ -118,7 +118,7 @@ function snow_snowball_ENTITY.on_activate(self)
 			if not object then
 				return
 			end
-			local vel_obj = object:getvelocity()
+			local vel_obj = object:get_velocity()
 			if not vel_obj
 			or vel_obj.y == 0 then
 				object:remove()
@@ -137,7 +137,7 @@ function snow_snowball_ENTITY.on_step(self, dtime)
 	end
 
 	if self.physical then
-		local vel = self.object:getvelocity()
+		local vel = self.object:get_velocity()
 		local fell = vel.y == 0
 		if not fell then
 			if self.probably_stuck then
@@ -155,7 +155,7 @@ function snow_snowball_ENTITY.on_step(self, dtime)
 			self.probably_stuck = nil
 			return
 		end
-		local pos = vector.round(self.object:getpos())
+		local pos = vector.round(self.object:get_pos())
 		if minetest.get_node(pos).name == "air" then
 			pos.y = pos.y-1
 			if minetest.get_node(pos).name == "air" then
@@ -171,16 +171,16 @@ function snow_snowball_ENTITY.on_step(self, dtime)
 		return
 	end
 
-	local pos = vector.round(self.object:getpos())
+	local pos = vector.round(self.object:get_pos())
 	if vector.equals(pos, self.lastpos) then
 		return
 	end
 	if minetest.get_node(pos).name ~= "air" then
-		self.object:setacceleration({x=0, y=-get_gravity(), z=0})
-		--self.object:setvelocity({x=0, y=0, z=0})
+		self.object:set_acceleration({x=0, y=-get_gravity(), z=0})
+		--self.object:set_velocity({x=0, y=0, z=0})
 		pos = self.lastpos
 		self.object:setpos(pos)
-		minetest.sound_play("default_snow_footstep", {pos=pos, gain=vector.length(self.object:getvelocity())/30})
+		minetest.sound_play("default_snow_footstep", {pos=pos, gain=vector.length(self.object:get_velocity())/30})
 		self.object:set_properties({physical = true})
 		self.physical = true
 		return
@@ -199,8 +199,8 @@ function snow_snowball_ENTITY.on_step(self, dtime)
 			or (entity_name ~= "snow:snowball_entity"
 			and entity_name ~= "__builtin:item"
 			and entity_name ~= "gauges:hp_bar") then
-				local vvel = v:getvelocity() or v:get_player_velocity()
-				local veldif = self.object:getvelocity()
+				local vvel = v:get_velocity() or v:get_player_velocity()
+				local veldif = self.object:get_velocity()
 				if vvel then
 					veldif = vector.subtract(veldif, vvel)
 				end


### PR DESCRIPTION
This PR fixes these warnings:
```
2021-04-24 07:56:03: WARNING[Server]: Call to deprecated function 'getpos', please use 'get_pos' at /home/minetest-pvp/.minetest/mods/snow/src/falling_snow.lua:99
2021-04-24 07:56:03: WARNING[Server]: Call to deprecated function 'get2d', please use 'get_2d' at /home/minetest-pvp/.minetest/mods/snow/src/falling_snow.lua:110
2021-04-24 07:56:03: WARNING[Server]: Call to deprecated function 'get2d', please use 'get_2d' at /home/minetest-pvp/.minetest/mods/snow/src/falling_snow.lua:111
2021-04-24 07:56:03: WARNING[Server]: Call to deprecated function 'get2d', please use 'get_2d' at /home/minetest-pvp/.minetest/mods/snow/src/falling_snow.lua:112
```
afaik just these